### PR TITLE
Replace iteritems() with items()

### DIFF
--- a/sphinxcontrib/domaintools.py
+++ b/sphinxcontrib/domaintools.py
@@ -126,7 +126,7 @@ class CustomDomain(Domain):
                             labelid, contnode)
 
     def get_objects(self):
-        for (type, name), info in self.data['objects'].iteritems():
+        for (type, name), info in self.data['objects'].items():
             yield (name, name, type, info[0], info[1],
                    self.object_types[type].attrs['searchprio'])
 


### PR DESCRIPTION
Should fix Python 3 compatibility.
Fixes Issue #1.