### PR TITLE
Auto-publish to PyPI on tags

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,28 @@
+name: Publish to PyPI
+
+on: push
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Publish to PyPI (on tag)
+      if: startsWith(github.event.ref, 'refs/tags/v')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
@tk0miya, this is an attempt to relieve any manual PyPI burden of merging changes to this package.

Copied from https://github.com/pygae/pyganja/blob/master/.github/workflows/pythonpublish.yml, where I set this up the other day.

For this to work, you will need to:
* Enable github actions (https://github.com/features/actions)
* Generate a PyPI token for just this repo (see http://pyfound.blogspot.com/2019/07/pypi-now-supports-uploading-via-api.html)
* Go https://github.com/sphinx-contrib/domaintools/settings/secrets
* Add your PyPI token as a new secret, with the name `pypi_password`