### PR TITLE
Fix warning about 4-column-based-index

### DIFF
--- a/sphinxcontrib/domaintools/__init__.py
+++ b/sphinxcontrib/domaintools/__init__.py
@@ -76,7 +76,7 @@ class GenericObject(ObjectDescription):
                 indextype = 'single'
                 indexentry = self.indextemplate % (name,)
             self.indexnode['entries'].append((indextype, indexentry,
-                                              targetname, ''))
+                                              targetname, '', None))
         self.env.domaindata[self.domain]['objects'][self.objtype, name] = \
             self.env.docname, targetname
 


### PR DESCRIPTION
Stops the message `WARNING: 4 column based index found. It might be a bug of extensions you use:` appearing, which is due to sphinx changing from 4- to 5-column indices.

This change will break compatibility with sphinx < 1.4.

Note that this is only a warning, so doesn't really block anything - filing this primarily for a destination for google searches of that warning.