### PR TITLE
Fix warning about 4-column-based-index

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ This package contains tools for easy sphinx domain creation.
 version_path = os.path.join('sphinxcontrib', 'domaintools', '_version.py')
 exec(open(version_path).read())
 
-requires = ['Sphinx>=1.0']
+requires = ['Sphinx>=1.4']
 
 setup(
     name='sphinxcontrib-domaintools',

--- a/sphinxcontrib/domaintools/__init__.py
+++ b/sphinxcontrib/domaintools/__init__.py
@@ -75,7 +75,7 @@ class GenericObject(ObjectDescription):
                 indextype = 'single'
                 indexentry = self.indextemplate % (name,)
             self.indexnode['entries'].append((indextype, indexentry,
-                                              targetname, ''))
+                                              targetname, '', None))
         self.env.domaindata[self.domain]['objects'][self.objtype, name] = \
             self.env.docname, targetname
 


### PR DESCRIPTION
Alternate to #7. Rebased, bumped the minimum supported version of Sphinx to 1.4 (Mar 2016). Pinging @tk0miya.